### PR TITLE
Add control panel section on landing page

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -187,6 +187,18 @@ function Login({ onSubmit = () => {}, loading = false }) {
               </Link>
             </Typography>
           </Grid>
+          <Grid item>
+            <Typography variant="body1">
+              <Link
+                className={classes.link}
+                href="https://github.com/QuoteVote/quotevote-react"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Source Code
+              </Link>
+            </Typography>
+          </Grid>
         </Grid>
       </CardBody>
     </Card>

--- a/src/components/Login/__snapshots__/Login.test.js.snap
+++ b/src/components/Login/__snapshots__/Login.test.js.snap
@@ -131,13 +131,29 @@ exports[`Login test - renders correctly 1`] = `
           />
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-link-7 MuiTypography-colorPrimary"
-            href="/auth/request-access"
-          >
-            Request Access
-          </a>
-        </p>
-      </div>
+          href="/auth/request-access"
+        >
+          Request Access
+        </a>
+      </p>
     </div>
+    <div
+      class="MuiGrid-root MuiGrid-item"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1"
+      >
+        <a
+          class="MuiTypography-root MuiLink-root MuiLink-underlineHover makeStyles-link-7 MuiTypography-colorPrimary"
+          href="https://github.com/QuoteVote/quotevote-react"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Source Code
+        </a>
+      </p>
+    </div>
+  </div>
   </div>
 </div>
 `;

--- a/src/views/LandingPage/LandingPage.js
+++ b/src/views/LandingPage/LandingPage.js
@@ -10,6 +10,7 @@ import {
   ListItem,
   Typography,
 } from '@material-ui/core'
+import ControlPanel from '../ControlPanel/ControlPanel'
 import { isMobile } from 'react-device-detect'
 import GridContainer from '../../mui-pro/Grid/GridContainer'
 import GridItem from '../../mui-pro/Grid/GridItem'
@@ -88,6 +89,21 @@ export default function LandingPage() {
           >
             Donate
           </Button>
+        </ListItem>
+        <ListItem className={classes.listItem}>
+          <Typography variant="body1">
+            <Link
+              style={{ color: '#00bcd4' }}
+              href="https://github.com/QuoteVote/quotevote-react"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Source Code
+            </Link>
+          </Typography>
+        </ListItem>
+        <ListItem className={classes.listItem}>
+          <ControlPanel />
         </ListItem>
         <ListItem className={classes.contact}>
           Contact


### PR DESCRIPTION
## Summary
- link to GitHub on landing page
- show ControlPanel under Donate button
- Visitors can see total number of invite requests and active users

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find a config)*
- `npm run test:coverage` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426c81de38832c8ae863334ff723bd