### PR TITLE
Implement frontend post deletion options

### DIFF
--- a/docs/backend-delete-post.md
+++ b/docs/backend-delete-post.md
@@ -1,0 +1,26 @@
+# Backend Changes for Post Deletion
+
+The frontend now expects a new GraphQL mutation called `deletePost` which allows
+post authors to remove their posts. Admin users may delete any post. When a
+post is deleted, requests to its route should return a `404` error.
+
+## Required API Updates
+
+1. **Add `deletePost` Mutation**
+   - Input: `postId: String!`
+   - Authorization: allow if the requesting user is the creator of the post or
+     has `admin` privileges.
+   - Response: minimal object with `_id` of the deleted post.
+
+2. **Enforce 404 on Deleted Posts**
+   - Update the resolver for `post(postId)` so that when the post does not exist
+     or is marked as deleted, the server returns `null` and an HTTP `404` status
+     code.
+
+3. **Update Schema and Tests**
+   - Add the new mutation and any necessary types to the GraphQL schema.
+   - Provide tests covering creator deletion, admin deletion, and the 404
+     response when fetching a deleted post.
+
+Once these backend updates are complete, the new delete button in the React
+app will function and removed posts will correctly show the error page.

--- a/src/components/Post/Post.jsx
+++ b/src/components/Post/Post.jsx
@@ -5,6 +5,7 @@ import {
 import { makeStyles } from '@material-ui/core/styles'
 import BlockIcon from '@material-ui/icons/Block'
 import LinkIcon from '@material-ui/icons/Link'
+import DeleteIcon from '@material-ui/icons/Delete'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
 import { useMutation } from '@apollo/react-hooks'
@@ -24,6 +25,7 @@ import {
   VOTE,
   APPROVE_POST,
   REJECT_POST,
+  DELETE_POST,
 } from '../../graphql/mutations'
 import {
   GET_POST,
@@ -248,6 +250,12 @@ function Post({
     ],
   });
 
+  const [deletePost] = useMutation(DELETE_POST, {
+    refetchQueries: [
+      { query: GET_TOP_POSTS, variables: { limit: 5, offset: 0, searchKey: '' } },
+    ],
+  });
+
   const handleReportPost = async () => {
     try {
       const res = await reportPost({ variables: { postId: _id, userId: user._id } })
@@ -464,6 +472,20 @@ function Post({
     }
   };
 
+  const handleDelete = async () => {
+    try {
+      await deletePost({ variables: { postId: _id } });
+      dispatch(
+        SET_SNACKBAR({ open: true, message: 'Post deleted', type: 'success' }),
+      );
+      history.push('/home');
+    } catch (err) {
+      dispatch(
+        SET_SNACKBAR({ open: true, message: `Delete Error: ${err.message}`, type: 'danger' }),
+      );
+    }
+  };
+
   return (
     <Card
       style={{
@@ -537,6 +559,11 @@ function Post({
             showIcon
           />
           <BookmarkIconButton post={post} user={user} />
+          {(user._id === userId || user.admin) && (
+            <IconButton onClick={handleDelete} size="small">
+              <DeleteIcon />
+            </IconButton>
+          )}
           {/* Add chat, person, and heart icons here as needed */}
         </div>
       </CardActions>

--- a/src/graphql/mutations.jsx
+++ b/src/graphql/mutations.jsx
@@ -239,3 +239,11 @@ export const REPORT_POST = gql`
     }
   }
 `
+
+export const DELETE_POST = gql`
+  mutation deletePost($postId: String!) {
+    deletePost(postId: $postId) {
+      _id
+    }
+  }
+`

--- a/src/views/PostsPage/PostPage.jsx
+++ b/src/views/PostsPage/PostPage.jsx
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { useQuery, useSubscription } from '@apollo/react-hooks'
 import { useSelector } from 'react-redux'
 import { isEmpty } from 'lodash'
-import Link from '@material-ui/core/Link'
+import { Redirect } from 'react-router-dom'
 import Post from '../../components/Post/Post'
 import PostActionList from '../../components/PostActions/PostActionList'
 import PostSkeleton from '../../components/Post/PostSkeleton'
@@ -84,7 +84,7 @@ function PostPage({ postId }) {
     },
   )
 
-  if (postError) return 'Something went wrong!'
+  if (postError) return <Redirect to="/error" />
 
   const { messages } = (!loadingMessages && messageData) || []
 
@@ -110,25 +110,7 @@ function PostPage({ postId }) {
   }
 
   if (!loadingPost && !post) {
-    return (
-      <Grid
-        container
-        direction="row"
-        justify="space-around"
-        alignItems="flex-start"
-        className={classes.root}
-        style={{ position: 'relative' }}
-      >
-        <Grid item xs={12} className={classes.emptyPost}>
-          <Typography variant="h6" align="center">
-            Invalid post
-          </Typography>
-          <Link href="/home" className={classes.link}>
-            Return to homepage.
-          </Link>
-        </Grid>
-      </Grid>
-    )
+    return <Redirect to="/error" />
   }
 
   const { url } = !loadingPost && post


### PR DESCRIPTION
## Summary
- allow authors or admins to delete posts from the UI
- redirect to the error page when a post is missing or deleted
- expose new `DELETE_POST` mutation
- document required backend changes for Codex

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a273f9af4832cafbf2e38e152b254