### PR TITLE
Replace plus icon in nav bar

### DIFF
--- a/src/components/Navbars/MainNavBar.jsx
+++ b/src/components/Navbars/MainNavBar.jsx
@@ -52,7 +52,7 @@ function MainNavBar(props) {
       <Grid
         container
         direction="row"
-        justify="space-between"
+        justify="flex-start"
         alignItems="center"
         wrap="nowrap"
       >
@@ -81,28 +81,25 @@ function MainNavBar(props) {
                 />
               </NavLink>
             </Grid>
-            <Grid item lg={4}>
-              <Tab
-                icon={(
-                  <img 
-                    src="/assets/AddPost.svg" 
-                    alt="Add Post" 
-                    style={{width: fontSize === 'large' ? '32px' : '24px', height: fontSize === 'large' ? '32px' : '24px'}} 
-                  />
-                )}
-                aria-label="Post"
-                onClick={() => {
-                  if (loggedIn) {
-                    handleMenu(2)
-                    setOpen(true)
-                  } else {
-                    history.push('/auth/request-access')
-                  }
-                }}
-                value="post"
-              />
-            </Grid>
           </Tabs>
+        </Grid>
+        <div className={classes.grow} />
+        <Grid item>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={() => {
+              if (loggedIn) {
+                handleMenu(2)
+                setOpen(true)
+              } else {
+                history.push('/auth/request-access')
+              }
+            }}
+            className={classes.rightMenuButton}
+          >
+            Create Quote
+          </Button>
         </Grid>
         {loggedIn ? (
           <Grid item>


### PR DESCRIPTION
## Summary
- remove the `+` icon from the main navigation bar
- add a `Create Quote` button instead
- keep login/invite buttons aligned to the right on smaller screens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint:check` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685b6fec8b28832c8793fcfc1a24b4b9