### PR TITLE
Add latest quotes feed on search page

### DIFF
--- a/src/components/Quotes/LatestQuotes.jsx
+++ b/src/components/Quotes/LatestQuotes.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+import { Paper, Typography, List, ListItem } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { GET_LATEST_QUOTES } from '../../graphql/query';
+
+export default function LatestQuotes({ limit = 5 }) {
+  const [quotes, setQuotes] = useState([]);
+  const { data } = useQuery(GET_LATEST_QUOTES, {
+    variables: { limit },
+    pollInterval: 3000,
+    fetchPolicy: 'network-only',
+  });
+
+  useEffect(() => {
+    if (data && data.latestQuotes) {
+      setQuotes((prev) => {
+        const existingIds = prev.map((q) => q._id);
+        const fresh = data.latestQuotes.filter((q) => !existingIds.includes(q._id));
+        return [...fresh, ...prev];
+      });
+    }
+  }, [data]);
+
+  return (
+    <Paper style={{ padding: 16 }}>
+      <Typography variant="h6" gutterBottom>
+        Latest Quotes
+      </Typography>
+      <List>
+        {quotes.map((q) => (
+          <ListItem key={q._id} style={{ display: 'block' }}>
+            <Typography variant="body2">
+              <strong>{q.user?.username}</strong>: {q.quote}
+            </Typography>
+          </ListItem>
+        ))}
+      </List>
+    </Paper>
+  );
+}
+
+LatestQuotes.propTypes = {
+  limit: PropTypes.number,
+};

--- a/src/graphql/query.jsx
+++ b/src/graphql/query.jsx
@@ -478,4 +478,16 @@ export const GET_NOTIFICATIONS = gql`
       }
     }
   }
+export const GET_LATEST_QUOTES = gql`
+  query latestQuotes($limit: Int!) {
+    latestQuotes(limit: $limit) {
+      _id
+      quote
+      created
+      user {
+        _id
+        username
+      }
+    }
+  }
 `

--- a/src/views/SearchPage/index.jsx
+++ b/src/views/SearchPage/index.jsx
@@ -15,6 +15,7 @@ import ErrorBoundary from '../../components/ErrorBoundary';
 import Carousel from '../../components/Carousel/Carousel';
 import PostCard from '../../components/Post/PostCard';
 import Divider from '@material-ui/core/Divider';
+import LatestQuotes from '../../components/Quotes/LatestQuotes';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -667,6 +668,12 @@ export default function SearchPage() {
                     </Typography>
                   )}
                 </Paper>
+              </Grid>
+            )}
+
+            {!isGuestMode && (
+              <Grid item style={{ width: '100%', maxWidth: 600 }}>
+                <LatestQuotes limit={5} />
               </Grid>
             )}
             


### PR DESCRIPTION
## Summary
- add `GET_LATEST_QUOTES` query
- create `LatestQuotes` component with polling
- show latest quotes on Search page for authenticated users

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7f6ca9e0832c90d308a597c0dfdc