### PR TITLE
Add simple avatar editor with save button

### DIFF
--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -33,7 +33,7 @@ function DisplayAvatar(props) {
   return (
     <>
       <Avatar
-        avatarStyle="Cicle"
+        avatarStyle="Circle"
         topType={topType}
         hatColor={hatColor}
         accessoriesType={accessoriesType}

--- a/src/components/Profile/SimpleAvatarEditor.jsx
+++ b/src/components/Profile/SimpleAvatarEditor.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+import { useMutation } from '@apollo/react-hooks'
+import { Button, Grid, FormControl, InputLabel, Select, MenuItem } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import AvatarDisplay from '../Avatar'
+import { avatarOptions } from '../../utils/display'
+import { UPDATE_USER_AVATAR } from '../../graphql/mutations'
+import { updateAvatar } from '../../store/user'
+
+const useStyles = makeStyles({
+  editor: { marginTop: 20 },
+  avatar: { marginBottom: 20 },
+  select: { minWidth: 160 },
+  buttonRow: { marginTop: 20 },
+})
+
+function getRandomAvatar() {
+  const randomAvatar = {}
+  avatarOptions.forEach((opt) => {
+    const idx = Math.floor(Math.random() * opt.options.length)
+    randomAvatar[opt.name] = opt.options[idx]
+  })
+  return randomAvatar
+}
+
+function SimpleAvatarEditor() {
+  const classes = useStyles()
+  const user = useSelector((state) => state.user.data)
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const [avatar, setAvatar] = useState(user.avatar || getRandomAvatar())
+  const [updateUserAvatar] = useMutation(UPDATE_USER_AVATAR)
+
+  const handleChange = (name) => (event) => {
+    setAvatar({ ...avatar, [name]: event.target.value })
+  }
+
+  const handleRandomize = () => {
+    setAvatar(getRandomAvatar())
+  }
+
+  const handleSave = async () => {
+    const result = await updateUserAvatar({
+      variables: { user_id: user._id, avatarQualities: avatar },
+    })
+    updateAvatar(dispatch, result.data.updateUserAvatar.avatar)
+    history.push('/Profile')
+  }
+
+  return (
+    <Grid container className={classes.editor} direction="column" alignItems="center">
+      <Grid item className={classes.avatar}>
+        <AvatarDisplay height={180} width={180} {...avatar} />
+      </Grid>
+      <Grid item container spacing={2} justify="center">
+        {avatarOptions.map((opt) => (
+          <Grid item key={opt.name}>
+            <FormControl className={classes.select}>
+              <InputLabel>{opt.displayName}</InputLabel>
+              <Select value={avatar[opt.name] || ''} onChange={handleChange(opt.name)}>
+                {opt.options.map((option) => (
+                  <MenuItem key={option} value={option}>
+                    {option}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        ))}
+      </Grid>
+      <Grid item container className={classes.buttonRow} spacing={2} justify="center">
+        <Grid item>
+          <Button variant="outlined" color="primary" onClick={handleRandomize}>
+            Randomize
+          </Button>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" color="primary" onClick={handleSave}>
+            Save Avatar
+          </Button>
+        </Grid>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default SimpleAvatarEditor

--- a/src/views/Profile/index.jsx
+++ b/src/views/Profile/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { Route } from 'react-router-dom'
 import Profile from 'components/Profile/ProfileController'
-import ChangePhoto from 'components/Profile/ChangePhoto'
+import SimpleAvatarEditor from 'components/Profile/SimpleAvatarEditor'
 import FollowInfo from 'components/Profile/FollowInfo'
 
 export default function ProfileRouter() {
@@ -17,7 +17,7 @@ export default function ProfileRouter() {
         <Profile />
       </Route>
       <Route exact path="/Profile/:username/avatar">
-        <ChangePhoto />
+        <SimpleAvatarEditor />
       </Route>
       <Route exact path="/Profile/:username/following">
         <FollowInfo filter="following" />


### PR DESCRIPTION
## Summary
- introduce **SimpleAvatarEditor** with dropdowns, randomize and save actions
- route profile avatar editing to the new component
- fix avataaars style typo so avatars render correctly

## Testing
- `npm run lint:check` *(fails: couldn't find eslint.config.js)*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685b7f5ca730832cbb4290541775f677