### PR TITLE
Implement search route with live quote stream

### DIFF
--- a/src/components/Notifications/NotificationMobileView.js
+++ b/src/components/Notifications/NotificationMobileView.js
@@ -6,10 +6,22 @@ import { makeStyles } from '@material-ui/core/styles'
 import { GET_NOTIFICATIONS } from '../../graphql/query'
 import { NEW_NOTIFICATION_SUBSCRIPTION } from '../../graphql/subscription'
 import NotificationContent from './Notification'
+import SubHeader from '../SubHeader'
 
 const useStyles = makeStyles((theme) => ({
   root: {
+    display: 'flex',
+    flexGrow: 1,
     backgroundColor: theme.palette.background.paper,
+  },
+  list: {
+    marginRight: 10,
+    maxWidth: '70%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '100%',
+      marginRight: 2,
+      marginLeft: 2,
+    },
   },
 }))
 
@@ -30,14 +42,26 @@ function NotificationMobileView() {
   const { notifications } = loading ? { notifications: [] } : data
 
   return (
-    <Grid className={classes.root}>
-      <NotificationContent
-        spacing={2}
-        loading={loading}
-        notifications={notifications}
-        refetch={refetch}
-        pageView
-      />
+    <Grid
+      container
+      direction="row"
+      justify="center"
+      alignItems="center"
+      className={classes.root}
+      spacing={2}
+    >
+      <Grid item xs={12}>
+        <SubHeader headerName="Notifications" showFilterIconButton={false} />
+      </Grid>
+      <Grid item xs={12} className={classes.list}>
+        <NotificationContent
+          spacing={2}
+          loading={loading}
+          notifications={notifications}
+          refetch={refetch}
+          pageView
+        />
+      </Grid>
     </Grid>
   )
 }

--- a/src/components/Quote/LatestQuotesStream.js
+++ b/src/components/Quote/LatestQuotesStream.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react'
+import { useQuery } from '@apollo/react-hooks'
+import { Grid } from '@material-ui/core'
+import { GET_LATEST_QUOTES } from '../../graphql/query'
+import QuoteCard from './QuoteCard'
+import LoadingSpinner from '../LoadingSpinner'
+
+export default function LatestQuotesStream({ paused }) {
+  const { data, loading, startPolling, stopPolling } = useQuery(GET_LATEST_QUOTES, {
+    variables: { limit: 1, offset: 0 },
+    pollInterval: 3000,
+    fetchPolicy: 'network-only',
+  })
+  const [quotes, setQuotes] = useState([])
+
+  useEffect(() => {
+    if (paused) {
+      stopPolling()
+    } else {
+      startPolling(3000)
+    }
+  }, [paused, startPolling, stopPolling])
+
+  useEffect(() => {
+    if (data && data.latestQuotes && data.latestQuotes.length) {
+      const newQuote = data.latestQuotes[0]
+      setQuotes((prev) => {
+        if (prev.find((q) => q._id === newQuote._id)) {
+          return prev
+        }
+        return [newQuote, ...prev]
+      })
+    }
+  }, [data])
+
+  return (
+    <Grid container direction="column" spacing={2}>
+      {quotes.map((q) => (
+        <Grid item key={q._id}>
+          <QuoteCard quote={q} />
+        </Grid>
+      ))}
+      {loading && quotes.length === 0 && (
+        <Grid item>
+          <LoadingSpinner size={30} />
+        </Grid>
+      )}
+    </Grid>
+  )
+}

--- a/src/components/Quote/QuoteCard.js
+++ b/src/components/Quote/QuoteCard.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { makeStyles } from '@material-ui/core/styles'
+import { Card, CardHeader, CardContent, Typography, Avatar } from '@material-ui/core'
+import AvatarDisplay from '../Avatar'
+import { useHistory } from 'react-router-dom'
+import moment from 'moment'
+
+const useStyles = makeStyles(() => ({
+  card: {
+    marginBottom: 8,
+    cursor: 'pointer',
+  },
+  quoteText: {
+    fontStyle: 'italic',
+    marginBottom: 8,
+  },
+  postTitle: {
+    fontWeight: 'bold',
+    textDecoration: 'underline',
+  },
+}))
+
+export default function QuoteCard({ quote }) {
+  const classes = useStyles()
+  const history = useHistory()
+
+  const handlePostClick = (e) => {
+    e.stopPropagation()
+    if (quote.post && quote.post.url) {
+      history.push(quote.post.url.replace(/\?/g, ''))
+    }
+  }
+
+  const handleProfileClick = (e) => {
+    e.stopPropagation()
+    if (quote.user && quote.user.username) {
+      history.push(`/Profile/${quote.user.username}`)
+    }
+  }
+
+  return (
+    <Card className={classes.card}>
+      <CardHeader
+        avatar={(
+          <Avatar onClick={handleProfileClick}>
+            {quote.user && <AvatarDisplay height="40" width="40" {...quote.user.avatar} />}
+          </Avatar>
+        )}
+        title={quote.user ? quote.user.username : 'Anonymous'}
+        subheader={moment(quote.created).calendar()}
+      />
+      <CardContent onClick={handlePostClick}>
+        <Typography className={classes.quoteText}>{quote.quote}</Typography>
+        {quote.post && (
+          <Typography variant="subtitle2" className={classes.postTitle}>
+            {quote.post.title}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+QuoteCard.propTypes = {
+  quote: PropTypes.object.isRequired,
+}

--- a/src/graphql/query.js
+++ b/src/graphql/query.js
@@ -416,3 +416,33 @@ export const GET_NOTIFICATIONS = gql`
     }
   }
 `
+
+export const GET_LATEST_QUOTES = gql`
+  query latestQuotes($limit: Int!, $offset: Int!) {
+    latestQuotes(limit: $limit, offset: $offset) {
+      _id
+      quote
+      created
+      startWordIndex
+      endWordIndex
+      user {
+        _id
+        name
+        username
+        avatar
+      }
+      post {
+        _id
+        title
+        url
+        text
+        creator {
+          _id
+          name
+          username
+          avatar
+        }
+      }
+    }
+  }
+`

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,6 +11,7 @@ import { ReactComponent as TrendingSvg } from './assets/svg/TrendingIcon.svg'
 import { ReactComponent as AddPostSvg } from './assets/svg/AddPost.svg'
 import { ReactComponent as NotificationsActiveSvg } from './assets/svg/NotificationsActive.svg'
 import NotificationMobileView from './components/Notifications/NotificationMobileView'
+import SearchView from 'views/SearchView/SearchView'
 
 const routes = [
   {
@@ -34,6 +35,12 @@ const routes = [
     name: 'Posts',
     icon: AddPostSvg,
     component: PostPage,
+    layout: '/',
+  },
+  {
+    path: 'search',
+    name: 'Search',
+    component: SearchView,
     layout: '/',
   },
   {

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -1,9 +1,75 @@
-import React, { PureComponent } from 'react'
+import React, { useState } from 'react'
+import { useQuery } from '@apollo/react-hooks'
+import { useSelector } from 'react-redux'
+import { Grid, IconButton } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import PauseIcon from '@material-ui/icons/Pause'
+import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import SubHeader from 'components/SubHeader'
+import FilterInputs from 'components/Filter/FilterInputs'
+import { GET_SEARCH_KEY } from 'components/SearchBar'
+import LatestQuotesStream from '../../components/Quote/LatestQuotesStream'
+import ErrorBoundary from '../../components/ErrorBoundary'
 
-class SearchView extends PureComponent {
-  render() {
-    return <div>Search View Page(todo)</div>
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexGrow: 1,
+  },
+  list: {
+    marginRight: 10,
+    maxWidth: '70%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '100%',
+      marginRight: 2,
+      marginLeft: 2,
+    },
+  },
+}))
+
+export default function SearchView() {
+  const classes = useStyles()
+  const filterState = useSelector((state) => state.filter)
+  const [offset, setOffset] = useState(0)
+  const [dateRangeFilter, setDateRangeFilter] = useState({ startDate: '', endDate: '' })
+  const [paused, setPaused] = useState(false)
+
+  useQuery(GET_SEARCH_KEY)
+
+  const handleToggle = () => {
+    setPaused((prev) => !prev)
   }
-}
 
-export default SearchView
+  return (
+    <ErrorBoundary>
+      <Grid container direction="row" justify="center" alignItems="center" className={classes.root} spacing={2}>
+        <Grid item xs={12}>
+          <SubHeader headerName="Search" setOffset={setOffset} showFilterIconButton={false} />
+        </Grid>
+        {filterState.filter.visibility || filterState.date.visibility || filterState.search.visibility ? (
+          <Grid item xs={12}>
+            <FilterInputs
+              filterState={filterState}
+              setOffset={setOffset}
+              selectAll={null}
+              handleSelectAll={() => {}}
+              handleActivityEvent={() => {}}
+              selectedEvent={null}
+              setDateRangeFilter={setDateRangeFilter}
+              dateRangeFilter={dateRangeFilter}
+              showFilterIconButton={false}
+            />
+          </Grid>
+        ) : null}
+        <Grid item xs={12}>
+          <IconButton onClick={handleToggle} aria-label="toggle-stream">
+            {paused ? <PlayArrowIcon /> : <PauseIcon />}
+          </IconButton>
+        </Grid>
+        <Grid item xs={12} className={classes.list}>
+          <LatestQuotesStream paused={paused} />
+        </Grid>
+      </Grid>
+    </ErrorBoundary>
+  )
+}

--- a/src/views/SearchView/SearchView.test.js
+++ b/src/views/SearchView/SearchView.test.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import withTestWrapper from '../../hoc/withTestWrapper'
+import SearchView from './SearchView'
+
+const SearchViewWrapper = withTestWrapper(SearchView)
+
+describe('SearchView test -', () => {
+  it('renders correctly', () => {
+    const { container } = render(<SearchViewWrapper />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## Summary
- add `GET_LATEST_QUOTES` query
- provide `QuoteCard` and `LatestQuotesStream` components
- implement `SearchView` with pause/play and stream
- register `/search` route
- snapshot test for SearchView

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c61cd9fdc832ca05731039feb4927