### PR TITLE
Replace flame icon with magnet

### DIFF
--- a/docs/search-features.md
+++ b/docs/search-features.md
@@ -10,9 +10,9 @@ The Search Page has been enhanced with new filtering and sorting capabilities us
 - **Visual Indicator**: Button turns blue when active
 - **Fallback**: If backend doesn't support native friends filtering, client-side filtering is used
 
-### 🔥 Interactions Sorting
+### 🧲 Interactions Sorting
 - **Functionality**: Sorts posts by total interactions (comments + votes + quotes)
-- **Usage**: Click the 🔥 button to toggle interaction-based sorting
+- **Usage**: Click the 🧲 button to toggle interaction-based sorting
 - **Visual Indicator**: Button turns blue when active
 - **Algorithm**: Posts with more interactions appear first
 

--- a/src/views/SearchPage/index.jsx
+++ b/src/views/SearchPage/index.jsx
@@ -583,7 +583,7 @@ export default function SearchPage() {
                 onClick={handleInteractionsFilter}
                 title="Sort by most interactions"
               >
-                🔥
+                🧲
               </IconButton>
               <IconButton 
                 aria-label="calendar" 
@@ -654,7 +654,7 @@ export default function SearchPage() {
                   <Typography variant="body2" color="textSecondary">
                     Active Filters:
                     {filterMode === 'friends' && ' 👥 Friends only'}
-                    {filterMode === 'interactions' && ' 🔥 Sorted by interactions'}
+                    {filterMode === 'interactions' && ' 🧲 Sorted by interactions'}
                     {dateRangeFilter.startDate && ` 📅 From ${format(dateRangeFilter.startDate, 'MMM d, yyyy')}`}
                     {dateRangeFilter.endDate && ` to ${format(dateRangeFilter.endDate, 'MMM d, yyyy')}`}
                   </Typography>
@@ -834,7 +834,7 @@ export default function SearchPage() {
               onClick={handleInteractionsFilter}
               title="Sort by most interactions"
             >
-              🔥
+              🧲
             </IconButton>
             <IconButton 
               aria-label="calendar" 
@@ -904,7 +904,7 @@ export default function SearchPage() {
                 <Typography variant="body2" color="textSecondary">
                   Active Filters:
                   {filterMode === 'friends' && ' 👥 Friends only'}
-                  {filterMode === 'interactions' && ' 🔥 Sorted by interactions'}
+                  {filterMode === 'interactions' && ' 🧲 Sorted by interactions'}
                   {dateRangeFilter.startDate && ` 📅 From ${format(dateRangeFilter.startDate, 'MMM d, yyyy')}`}
                   {dateRangeFilter.endDate && ` to ${format(dateRangeFilter.endDate, 'MMM d, yyyy')}`}
                 </Typography>


### PR DESCRIPTION
## Summary
- swap flame emoji for magnet emoji on Search Page filters
- update docs to reflect new magnet icon

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e09660e6c832c8d9abcded075e029